### PR TITLE
JSON cannot parse a plaintext

### DIFF
--- a/lib/insight/connection.rb
+++ b/lib/insight/connection.rb
@@ -15,14 +15,13 @@ module Insight
 
     def query(method, path, payload={})
       uri = endpoint_uri path
-
       begin
         response = RestClient::Request.execute method: method,  url: uri,  payload: payload,  ssl_version: 'SSLv23'
+        return response unless response.include?('{')
+        JSON.parse response, symbolize_names: true
       rescue Exception => e
         response = e.response
       end
-
-      JSON.parse response, symbolize_names: true
     end
 
     private

--- a/lib/insight/connection.rb
+++ b/lib/insight/connection.rb
@@ -17,11 +17,11 @@ module Insight
       uri = endpoint_uri path
       begin
         response = RestClient::Request.execute method: method,  url: uri,  payload: payload,  ssl_version: 'SSLv23'
-        return response unless response.include?('{')
-        JSON.parse response, symbolize_names: true
       rescue Exception => e
         response = e.response
       end
+      return response unless response.include?('{')
+      JSON.parse response, symbolize_names: true
     end
 
     private


### PR DESCRIPTION
JSON.parse is design to parse a serialized object or array hash.., Error when parsing a plan text. what a error 